### PR TITLE
Update pip install link to point to forked repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ You will need a `python 3.10` environment created with conda.
 Then, simply run
 
 ```
-pip install git+https://github.com/simone-mastrogiovanni/icarogw.git
+pip install git+https://github.com/icarogw-developers/icarogw.git
 ```
 
 To install the latest version of icarogw


### PR DESCRIPTION
A minor change which updates the pip install link in the README to point to the forked repository.

